### PR TITLE
first pass of TopicSearchResult and the ability to search topics through the frontend (which is accessible through /topics)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,13 +10,14 @@ import NewsSourceScoresPage from './pages/NewsSourceScoresPage';
 import NotFoundPage from './pages/NotFoundPage';
 import ContributePage from './pages/ContributePage';
 import FeedbackPage from './pages/FeedbackPage';
+import TopicPage from './pages/TopicPage';
 
 const styles = (theme: Theme) => createStyles({
   root: {
     textAlign: 'center',
   },
   contentRoot: {
-    margin: theme.spacing(2),
+    margin: theme.spacing(4),
   }
 });
 
@@ -34,6 +35,7 @@ const App: React.FC<WithStyles<typeof styles>> = (props) => {
             <Switch>
               <Route exact path={['/']} component={NewsSourceScoresPage} />
               <Route exact path={['/about']} component={ContributePage} />
+              <Route exact path={['/topics']} component={TopicPage} />
               {/* <Route exact path={['/feedback']} component={FeedbackPage}/> */}
               <Route component={NotFoundPage} />
             </Switch>

--- a/src/components/TopicSearchResult.tsx
+++ b/src/components/TopicSearchResult.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { GetTopicResult } from '../services/TopicService';
+import { Typography, Card, CardHeader, Grid, CardContent, makeStyles, CardMedia } from '@material-ui/core';
+import PageSection from './PageSection';
+
+interface TopicSearchResultProps {
+  getTopicResult: GetTopicResult;
+}
+
+const useStyles = makeStyles(theme => ({
+  newsArticleCard: {
+    height: '100%',
+    width: '100%',
+    textAlign: 'left',
+  },
+  newsArticleCardContainer: {
+    padding: theme.spacing(2),
+  },
+  media: {
+    height: '128px',
+  }
+}));
+
+const TopicSearchResult: React.FC<TopicSearchResultProps> = (props) => {
+  const { getTopicResult } = props;
+  const classes = useStyles();
+  if (getTopicResult.score === null) {
+    return <>
+      <Typography variant="h2">Cannot find news articles</Typography>
+      <Typography>Please try another topic.</Typography>
+    </>
+  }
+  return <>
+    <PageSection>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={6}>
+          <Typography variant="h3">Result</Typography>
+          <Typography variant="h2">{getTopicResult.score.toFixed(4)}</Typography>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <Typography variant="h3">News articles analyzed</Typography>
+          <Typography variant="h2">
+            {getTopicResult.newsArticlesAnalyzed}
+          </Typography>
+        </Grid>
+        <Grid item container xs={12} justify="center">
+          <Grid item xs={12}>
+            <Typography variant="h3">Sample news articles</Typography>
+          </Grid>
+          {getTopicResult.sampleAnalyzedArticles
+            .slice(0, 4)
+            .map(article => (
+              <Grid item xs={12} sm={6} md={3} className={classes.newsArticleCardContainer}>
+                <Card className={classes.newsArticleCard}>
+                  <CardMedia
+                    className={classes.media}
+                    image={article.imageUrl}
+                    title={article.title}
+                  />
+                  <CardHeader title={article.title} />
+                  <CardContent>
+                    {article.content}
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+        </Grid>
+      </Grid>
+    </PageSection>
+  </>;
+}
+
+export default TopicSearchResult;

--- a/src/mocks/getTopicScoreMock.ts
+++ b/src/mocks/getTopicScoreMock.ts
@@ -1,0 +1,321 @@
+export default {
+    "score": 0.242,
+    "newsArticlesAnalyzed": 45,
+    "sampleAnalyzedArticles": [
+        {
+            "content": "If you get your news from Facebook, that’s problem number one. Why? Well, it would take an effort of pandemic-response-sized proportions to get people to stop sharing bullshit on Facebook. And you see how well our pandemic response is going...Read more...",
+            "title": "Fight Coronavirus BS in Your Facebook Newsfeed",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/vmv9xpqz0tychsbkfkcb.png",
+            "url": "https://lifehacker.com/how-to-help-facebook-fight-coronavirus-bs-in-your-newsf-1842925605"
+        },
+        {
+            "content": "News fatigue isn't new. But it could indicate problematic changes in our behavior with respect to the pandemic.",
+            "title": "Coronavirus News Fatigue Is Officially Setting In",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e99db6fd42e6f0008f47b5d/191:100/w_1280,c_limit/Cul-handshadow-3137893.jpg",
+            "url": "https://www.wired.com/story/coronavirus-news-fatigue-is-officially-setting-in/"
+        },
+        {
+            "content": "The severity of the COVID-19 pandemic is the perfect backdrop for scammers to try and sucker you with schemes. We’ve seen fake coronavirus tracker apps and fake charities, and now coronavirus-related phishing scams are on the rise, too. Read more...",
+            "title": "Don't Get Suckered by These Coronavirus Phishing Scams",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/ecjafvgqmiokbcpl2bzw.jpg",
+            "url": "https://lifehacker.com/dont-get-suckered-by-these-coronavirus-phishing-scams-1842967378"
+        },
+        {
+            "content": "A heroic effort.",
+            "title": "Today's Cartoon: Coronavirus Battle",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e908b437b575f0008effd41/191:100/w_1280,c_limit/20200413-eckstein-coronavirus.jpg",
+            "url": "https://www.wired.com/story/wired-cartoons-week-35/"
+        },
+        {
+            "content": "Even a bug this ruthless has a few fatal weaknesses of its own.",
+            "title": "All the Ways to Kill a Coronavirus (So Far)",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e9b20fd04fd570008ac40d7/191:100/w_1280,c_limit/coronavirus_arsenal_web.jpg",
+            "url": "https://www.wired.com/story/all-the-ways-to-kill-a-coronavirus-so-far/"
+        },
+        {
+            "content": "No, drinking water won’t flush the virus out of your mouth. Here’s how to inoculate yourself against bad Covid-19 information.",
+            "title": "The Biggest Coronavirus Myths, Busted",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e877eadd036ef00088bfbe1/191:100/w_1280,c_limit/Science_myths-1127352024.jpg",
+            "url": "https://www.wired.com/story/the-biggest-coronavirus-myths-busted/"
+        },
+        {
+            "content": "If you don’t typically file a tax return, you’re running out of time to request the $500-per-child coronavirus relief payment for your kids.Read more...",
+            "title": "Non-Filers, Request Coronavirus Relief Payment for Your Kids by Tomorrow",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/ed31nhxni0m6cuu7wtq0.jpg",
+            "url": "https://twocents.lifehacker.com/non-filers-request-coronavirus-relief-payment-for-your-1842981763"
+        },
+        {
+            "content": "Here’s the thing about a pandemic: it’s everywhere. Everybody wants to read something reassuring. Everybody wants to say something useful. Everybody thinks their perspective matters. And most of us should just shut up so we can hear the actual experts speak. …",
+            "title": "How to Spot a Fake Coronavirus Expert",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/xnyngpxboljwsvwkcn98.jpg",
+            "url": "https://vitals.lifehacker.com/how-to-spot-a-fake-coronavirus-expert-1842780723"
+        },
+        {
+            "content": "A team of critical care specialists has a side project debunking questionable coronavirus theories for other medical professionals.",
+            "title": "The Covid-19 Newsletter That's By Doctors for Doctors",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e99e7123b394a0009a74daf/191:100/w_1280,c_limit/Science_MGH_Feautre_1209562968.jpg",
+            "url": "https://www.wired.com/story/the-covid-19-newsletter-thats-by-doctors-for-doctors/"
+        },
+        {
+            "content": "Sure, emissions have fallen. But a closer look at how the global crisis is influencing the environment reveals some surprising dynamics.",
+            "title": "How Is the Coronavirus Pandemic Affecting Climate Change?",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e9e0cc49508bf00082ebf37/191:100/w_1280,c_limit/Science_climate_1208550228.jpg",
+            "url": "https://www.wired.com/story/coronavirus-pandemic-climate-change/"
+        },
+        {
+            "content": "More than 12 government-backed groups are using the pandemic as cover for digital reconnaissance and espionage, according to a new report.",
+            "title": "Google Sees State-Sponsored Hackers Ramping Up Coronavirus Attacks",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e98ebe4ca6a510009874705/191:100/w_1280,c_limit/feature_art-covid_gmail_phish-850916440.jpg",
+            "url": "https://www.wired.com/story/google-state-sponsored-hackers-coronavirus-phishing-malware/"
+        },
+        {
+            "content": "Amazon is temporarily extending its return policy window to help its customers during the coronavirus crisis. If you live in the US or Canada, you now have until May 31st to return any products you buy between now and April 30th through Amazon or one of the c…",
+            "title": "Amazon extends return window amid coronavirus pandemic",
+            "sourceName": "Engadget",
+            "imageUrl": "https://o.aolcdn.com/images/dims?resize=1200%2C630&crop=1200%2C630%2C0%2C0&quality=80&image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-images%2F2020-01%2F678dfae0-4201-11ea-b87b-5e2f71517bcc&client=amp-blogside-v2&signature=cc9716ddc9614f0f9ed4d6a8fac68dd4be9fdec4",
+            "url": "https://www.engadget.com/amazon-extends-return-window-coronavirus-191126398.html"
+        },
+        {
+            "content": "The Committee to Protect Journalists, Access Now, the EFF, and other organizations have asked social media companies to preserve misinformation takedown data during the coronavirus pandemic for future research and transparency purposes.",
+            "title": "Researchers want social media companies to preserve coronavirus misinformation data",
+            "sourceName": "The Verge",
+            "imageUrl": "https://cdn.vox-cdn.com/thumbor/JWyFOz4J50OiF8OyksnvSytzDMs=/0x146:2040x1214/fit-in/1200x630/cdn.vox-cdn.com/uploads/chorus_asset/file/11560007/akrales_180614_1777_0121.jpg",
+            "url": "https://www.theverge.com/2020/4/22/21231061/cpj-access-now-researchers-letter-social-media-platform-coronavirus-preserve-misinformation-data"
+        },
+        {
+            "content": "Music, binge-watching, sourdough starters—these things are helping people cope. Will coronavirus also ruin them forever?",
+            "title": "The Pandemic Can Taint the Memory of Things We Love",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e973f52ca6a5100098746fe/191:100/w_1280,c_limit/Cul-fionaapple-630249630.jpg",
+            "url": "https://www.wired.com/story/culture-coronavirus-covid-19-memories/"
+        },
+        {
+            "content": "On March 11, 2020, the coronavirus pandemic seemed to crystalize in the national consciousness. Americans look back on the turning point.",
+            "title": "An Oral History of the Day Everything Changed",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5ea1de1ad42e6f0008f47b8d/191:100/w_1280,c_limit/WIred_covidSpring_4.png",
+            "url": "https://www.wired.com/story/an-oral-history-of-the-day-everything-changed-coronavirus/"
+        },
+        {
+            "content": "WIRED editor in chief Nicholas Thompson talks to branding expert Amanda Brinkman about how America’s small businesses are coping with coronavirus",
+            "title": "Now Is the Time for Main Street Shops to Go Digital",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5ea1f9fb001a9300085621d1/191:100/w_1280,c_limit/Biz-DCstore-1210300395.jpg",
+            "url": "https://www.wired.com/story/now-is-time-main-street-shops-go-digital/"
+        },
+        {
+            "content": "Hundreds of academics across the world have welcomed efforts to introduce privacy-friendly contact tracing systems to help understand the spread of coronavirus. A letter, signed by nearly 300 academics and published Monday, praised recent announcements from A…",
+            "title": "Hundreds of academics back privacy-friendly coronavirus contact tracing apps",
+            "sourceName": "TechCrunch",
+            "imageUrl": "https://techcrunch.com/wp-content/uploads/2020/04/GettyImages-1207755791.jpg?w=600",
+            "url": "http://techcrunch.com/2020/04/20/academics-contact-tracing/"
+        },
+        {
+            "content": "Amid more reports of pets and other animals testing positive for the new coronavirus, the Centers for Disease Control and Prevention updated its guidelines on social distancing this month to include our furry companions. However, there’s no evidence that pets…",
+            "title": "First U.S. Dog Tests Positive for Coronavirus",
+            "sourceName": "Gizmodo.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/rzqrhfoepzsochq1mhjg.jpg",
+            "url": "https://gizmodo.com/first-u-s-dog-tests-positive-for-coronavirus-1843131824"
+        },
+        {
+            "content": "Facebook has already come under fire for hosting groups organizing anti-quarantine protests in response to government lockdowns amid the coronavirus outbreak, and those promoting fake coronavirus cures and misinformation. Now it’s trying to figure out what to…",
+            "title": "Coronavirus-related Facebook support groups reach 4.5M in U.S, as misinformation and conspiracies spread",
+            "sourceName": "TechCrunch",
+            "imageUrl": "https://techcrunch.com/wp-content/uploads/2019/10/facebook-app.jpg?w=640",
+            "url": "http://techcrunch.com/2020/04/21/coronavirus-related-facebook-groups-reach-4-5m-in-u-s-as-misinformation-and-conspiracies-spread/"
+        },
+        {
+            "content": "Here are the brave men who aren’t letting a lack of relevant training stop them from weighing in on how to solve the crisis.",
+            "title": "Trump’s Coronavirus ‘Experts’: A Field Guide",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e8cf073a8fb770008c8473b/191:100/w_1280,c_limit/Ideas_Art_Trump-PhDism-1208287272.jpg",
+            "url": "https://www.wired.com/story/trumps-coronavirus-experts-a-field-guide/"
+        },
+        {
+            "content": "Coronavirus credentialism is rampant and dangerous. Knowing who's legit and who's an opportunist can save lives.",
+            "title": "Don't Be Fooled by Covid-19 Carpetbaggers",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e87c9f7845a6c00080f0ed7/191:100/w_1280,c_limit/OpEd-COVID-19-Expert-1215356017.jpg",
+            "url": "https://www.wired.com/story/opinion-dont-be-fooled-by-covid-19-carpetbaggers/"
+        },
+        {
+            "content": "Photographer Julia Keil finds inspiration in art as she turns the camera on herself while in isolation.",
+            "title": "Coronavirus: Dressing up in isolation",
+            "sourceName": "BBC News",
+            "imageUrl": "https://ichef.bbci.co.uk/news/1024/branded_news/180B5/production/_111858489_11_covid_19_lockdown_portrait_privacy_day20.jpg",
+            "url": "https://www.bbc.co.uk/news/in-pictures-52353298"
+        },
+        {
+            "content": "As cities across the U.S. began to issue “safer at home” orders, I felt like the only person I knew who didn’t have an ambitious project or three to tackle during the coronavirus. Read more...",
+            "title": "Manage Your Coronavirus Cleaning Urges With This Organizational App",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/rxzjya03miy9ej2hk8dp.jpg",
+            "url": "https://lifehacker.com/manage-your-coronavirus-cleaning-urges-with-this-organi-1842585282"
+        },
+        {
+            "content": "If you’re out of work or on a reduced schedule during the coronavirus pandemic, your government relief payment that could arrive as early as this week is likely a welcome addition to your bank account. Read more...",
+            "title": "The Case for Saving Your Coronavirus Relief Check",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/envoqfik8ldsso4o1x9r.jpg",
+            "url": "https://twocents.lifehacker.com/the-case-for-saving-your-coronavirus-relief-check-1842704915"
+        },
+        {
+            "content": "Recent world events may have led you to believe that this would be a bad time to not have health insurance right now. And while we can’t judge your individual need for insurance, we can probably say that in general, you should think about getting coverage. Re…",
+            "title": "How to Get Health Insurance During the Coronavirus Pandemic",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/zghdcypczfzr6rzfmc89.jpg",
+            "url": "https://lifehacker.com/how-to-get-health-insurance-during-the-coronavirus-pand-1842759127"
+        },
+        {
+            "content": "As the coronavirus pandemic continues to develop, you might be concerned about the long-term impact any changes to your finances could have on your credit. Relief checks and delayed payment timelines are helpful, but can they ultimately hurt your credit score…",
+            "title": "How to Protect Your Credit During the Coronavirus Shutdown",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/mhjjqrhltfapb0wcvera.jpg",
+            "url": "https://twocents.lifehacker.com/how-to-protect-your-credit-during-the-coronavirus-shutd-1842776060"
+        },
+        {
+            "content": "Among the many contemplative moments brought on by weeks of pandemic-induced isolation, you might be asking yourself whether you should get life insurance—or whether your existing policy covers death due to the coronavirus. Read more...",
+            "title": "Can You Still Get Life Insurance During the Coronavirus Pandemic?",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/tvzki1qtrw0qp0wuxyrc.jpg",
+            "url": "https://twocents.lifehacker.com/can-you-still-get-life-insurance-during-the-coronavirus-1842783590"
+        },
+        {
+            "content": "If you’re anxious about when your coronavirus relief payment will arrive—or where to look for the money—you can now get answers to those questions. Read more...",
+            "title": "How to Check the Status of Your Coronavirus Relief Payment",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/o45nfkvzttd7susnmn5n.jpg",
+            "url": "https://twocents.lifehacker.com/how-to-check-the-status-of-your-coronavirus-relief-paym-1842868515"
+        },
+        {
+            "content": "If, like me, you’re someone with an anxiety disorder, this whole pandemic situation has probably made things especially difficult for you. And given all the uncertainty and our lack of control over pretty much everything right now, even those who typically do…",
+            "title": "Download This Free Workbook on Anxiety and the Coronavirus",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/ar0eolfuuqq6xi8xn4qj.jpg",
+            "url": "https://lifehacker.com/download-this-free-workbook-on-anxiety-and-the-coronavi-1842886965"
+        },
+        {
+            "content": "Read more...",
+            "title": "What We Know About the Coronavirus So Far",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/ekpenwnlgftwsxdulpsf.jpg",
+            "url": "https://vitals.lifehacker.com/what-we-know-about-the-coronavirus-so-far-1842600467"
+        },
+        {
+            "content": "In a daily briefing on April 10th, the Donald Trump ranted about how a brilliant coronavirus was outwitting antibiotics. Now, that rant is going viral on TikTok.",
+            "title": "TikTokkers are clowning on President Trump’s bizarre antibiotics rant",
+            "sourceName": "The Verge",
+            "imageUrl": "https://cdn.vox-cdn.com/thumbor/XtqPtEg4n4mOfh5JsAJzdRUpG6M=/0x0:2245x1175/fit-in/1200x630/cdn.vox-cdn.com/uploads/chorus_asset/file/19915265/1220026120.jpg.jpg",
+            "url": "https://www.theverge.com/2020/4/21/21229609/trump-antibiotics-rant-tiktok-meme-audio-clip"
+        },
+        {
+            "content": "The new coronavirus has some stark differences from other relatively recent, grim outbreaks of disease. \nTake, for example, the SARS outbreak in 2003 (also a coronavirus), the H1N1 flu in 2009, or even the ongoing HIV epidemic. They don't compare for a number…",
+            "title": "Stop comparing coronavirus to other deadly viruses",
+            "sourceName": "Mashable",
+            "imageUrl": "https://mondrian.mashable.com/2020%252F04%252F21%252F32%252F8f64f02654284236b769d880485445cb.ccde1.jpg%252F1200x630.jpg?signature=etC7iwH2RWiIQZJNXb9MkRst4WY=",
+            "url": "https://mashable.com/article/coronavirus-versus-sars-flu-hiv/"
+        },
+        {
+            "content": "When the government paused payments and interest accrual for all federal student loans during the coronavirus outbreak, it felt like a free pass for many borrowers. Read more...",
+            "title": "What Happens If You Don't Pay Your Student Loans Until After the Pandemic?",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/gtdq9vthava5yryag9vu.jpg",
+            "url": "https://twocents.lifehacker.com/what-happens-if-you-dont-pay-your-student-loans-until-a-1842861361"
+        },
+        {
+            "content": "While a lot of the items in the coronavirus relief bill are temporary, here’s one that can benefit your tax returns for years to come. Read more...",
+            "title": "This New Deduction on Your 2020 Tax Return Rewards Charitable Contributions",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/jj6ld3gul4aacoct7jfx.jpg",
+            "url": "https://twocents.lifehacker.com/this-new-deduction-on-your-2020-tax-return-rewards-char-1842625403"
+        },
+        {
+            "content": "The IRS has launched an online form for people who don’t usually file tax returns to request their coronavirus relief check via direct deposit. Read more...",
+            "title": "How to Request Your Coronavirus Relief Check if You Don't File Taxes",
+            "sourceName": "Lifehacker.com",
+            "imageUrl": "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/qa1ciqe5atdrd05o0oh7.jpg",
+            "url": "https://twocents.lifehacker.com/how-to-request-your-coronavirus-relief-check-if-you-don-1842793951"
+        },
+        {
+            "content": "Twitter is making it a lot easier for researchers and developers to study conversations about the coronavirus on its platform. The company introduced a new set of tools that makes the “many tens of millions” of daily public tweets about the coronavirus availa…",
+            "title": "Twitter unlocks tools to help researchers study COVID-19 tweets",
+            "sourceName": "Engadget",
+            "imageUrl": "https://o.aolcdn.com/images/dims?resize=1200%2C630&crop=1200%2C630%2C0%2C0&quality=80&image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-images%2F2020-04%2F1863e440-7f12-11ea-afe7-1a398b7fded7&client=amp-blogside-v2&signature=c78bdb0ca551fff583872bed038d5de65e474645",
+            "url": "https://www.engadget.com/twitter-will-let-researchers-study-tweets-about-coronavirus-192948907.html"
+        },
+        {
+            "content": "Spain is the worst-affected country behind Italy, but ministers are hopeful the curve is flattening.",
+            "title": "Coronavirus: Hard-hit Spain's coronavirus outbreak 'slowing'",
+            "sourceName": "BBC News",
+            "imageUrl": "https://ichef.bbci.co.uk/news/1024/branded_news/3D79/production/_111473751_gettyimages-1214010712-1.jpg",
+            "url": "https://www.bbc.co.uk/news/world-52092898"
+        },
+        {
+            "content": "Doctors call the president's latest remarks about coronavirus treatment \"dangerous\" and \"ridiculous\".",
+            "title": "Coronavirus: Trump suggests injecting disinfectant as treatment",
+            "sourceName": "Bbc.com",
+            "imageUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p08bc3gc.jpg",
+            "url": "https://www.bbc.com/news/world-us-canada-52407177"
+        },
+        {
+            "content": "Advertisers are cancelling contracts with influencers who can’t travel to create content in lockdown.",
+            "title": "Coronavirus: Influencers' glossy lifestyles lose their shine",
+            "sourceName": "Bbc.com",
+            "imageUrl": "https://ichef.bbci.co.uk/news/1024/branded_news/7203/production/_111878192_insta.png",
+            "url": "https://www.bbc.com/news/business-52362462"
+        },
+        {
+            "content": "Apple and Google have detailed the latest privacy protections for their ambitious COVID-19 tracking collaboration via a series of technical documents on their cryptography, API and Bluetooth specifications.Namely, Bluetooth metadata — sometimes containing sma…",
+            "title": "Google and Apple detail privacy measures ahead of coronavirus tracking tests",
+            "sourceName": "Engadget",
+            "imageUrl": "https://o.aolcdn.com/images/dims?resize=1200%2C630&crop=1200%2C630%2C0%2C0&quality=80&image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2020-04%2Fcc83a9a0-8639-11ea-bdbf-5a4f339aa527&client=amp-blogside-v2&signature=4f1ad621d68a77b47fea5801136fff06e3e0117b",
+            "url": "https://www.engadget.com/google-apple-coronavirus-bluetooth-privacy-161522455.html"
+        },
+        {
+            "content": "Jemima Yong's pictures record the comings and goings on a patch of land outside her London home.",
+            "title": "Coronavirus: The view from my window",
+            "sourceName": "BBC News",
+            "imageUrl": "https://ichef.bbci.co.uk/news/1024/branded_news/FBC2/production/_111805446_7.jemimayongphotofromtheseriesfield2020.jpg",
+            "url": "https://www.bbc.co.uk/news/in-pictures-52298901"
+        },
+        {
+            "content": "Immunity is the crucial question and understanding it will tell us how the pandemic will end.",
+            "title": "Coronavirus immunity: Can you catch it twice?",
+            "sourceName": "Bbc.com",
+            "imageUrl": "https://ichef.bbci.co.uk/news/1024/branded_news/64F9/production/_111994852_gettyimages-1210284242-1.jpg",
+            "url": "https://www.bbc.com/news/health-52446965"
+        },
+        {
+            "content": "Rights groups say coronavirus restrictions are leaving vulnerable trans people even more exposed.",
+            "title": "Coronavirus: Transgender people 'extremely vulnerable' during lockdown",
+            "sourceName": "BBC News",
+            "imageUrl": "https://ichef.bbci.co.uk/news/1024/branded_news/15CF0/production/_111982398_global-lockdown.jpg",
+            "url": "https://www.bbc.co.uk/news/world-52457681"
+        },
+        {
+            "content": "Normally a time when people gather to break their fasts and pray, many are marking Ramadan alone.",
+            "title": "Ramadan: Muslims fast under coronavirus lockdowns",
+            "sourceName": "Bbc.com",
+            "imageUrl": "https://ichef.bbci.co.uk/news/1024/branded_news/E2BD/production/_111954085_tv061206373.jpg",
+            "url": "https://www.bbc.com/news/world-52428992"
+        },
+        {
+            "content": "The game's release is being postponed due to logistical concerns caused by the spread of the coronavirus.",
+            "title": "'The Last of Us Part II' Is Being Delayed Indefinitely",
+            "sourceName": "Wired",
+            "imageUrl": "https://media.wired.com/photos/5e87ac23adfa9d0008e095fc/191:100/w_1280,c_limit/Cul-rdonk4uvyh8ijanrbs46.jpg",
+            "url": "https://www.wired.com/story/last-of-us-2-delayed-indefinitely/"
+        }
+    ]
+}

--- a/src/pages/TopicPage.tsx
+++ b/src/pages/TopicPage.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { TextField, makeStyles, Grid, Box, Typography, Button, LinearProgress } from '@material-ui/core';
+import PageSection from '../components/PageSection';
+import TopicService, { GetTopicResult } from '../services/TopicService';
+import parseError from '../utils/parseError';
+import TopicSearchResult from '../components/TopicSearchResult';
+
+const useStyles = makeStyles(theme => ({
+  topicSearchField: {
+    width: '100%',
+  },
+  topicSearchFormElement: {
+    marginLeft: theme.spacing(2),
+    marginRight: theme.spacing(2),
+    marginTop: 'auto',
+    marginBottom: 'auto',
+  },
+  topicSearchFormContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignContent: 'center',
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+    },
+    [theme.breakpoints.up('md')]: {
+      flexDirection: 'row',
+    }
+  }
+}));
+
+const TopicPage: React.FC = () => {
+  const [topic, setTopic] = React.useState('');
+  const [data, setData] = React.useState<GetTopicResult | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const classes = useStyles();
+  function onSearch(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    loadData();
+  }
+  function loadData() {
+    setIsLoading(true);
+    setError(null);
+    TopicService.searchTopic(topic)
+      .then(res => setData(res))
+      .catch(e => setError(parseError(e)))
+      .finally(() => setIsLoading(false));
+  }
+  // React.useEffect(loadData, []);
+  return <>
+    <PageSection>
+      <Typography variant="h1">Topic Sentiment Viewer</Typography>
+      <Typography variant="subtitle1">How negative are your everyday topics?</Typography>
+    </PageSection>
+    <form onSubmit={onSearch} className={classes.topicSearchFormContainer}>
+        <TextField
+          id="search-topic-query"
+          label="Search for a topic"
+          helperText="(e.g. you can search for Donald Trump or Coronavirus)"
+          margin="normal"
+          name="searchTopicQuery"
+          fullWidth
+          value={topic}
+          onChange={(event) => setTopic(event.target.value as string)}
+          variant="outlined"
+          className={classes.topicSearchField}
+          required
+        />
+        <div className={classes.topicSearchFormElement}>
+          <Button variant="contained" color="primary" type="submit">Search</Button>
+        </div>
+    </form>
+    {isLoading && <LinearProgress />}
+    {error && error}
+    {data && <TopicSearchResult getTopicResult={data} />}
+    
+  </>;
+};
+
+export default TopicPage;

--- a/src/services/TopicService.ts
+++ b/src/services/TopicService.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { backendUrl, shouldMock } from '../config/constants';
+import getTopicScoreMock from '../mocks/getTopicScoreMock';
+import { OnlineNewsArticle } from '../typedefs';
+
+export type GetTopicResult = {
+  score: number | null;
+  newsArticlesAnalyzed: number;
+  sampleAnalyzedArticles: Array<OnlineNewsArticle>;
+};
+
+async function searchTopic(topic: string): Promise<GetTopicResult> {
+  if (shouldMock) {
+    return Promise.resolve(getTopicScoreMock);
+  }
+  return axios.post(backendUrl + '/topic-search', {
+    topic: topic,
+  }).then(res => res.data);
+}
+
+export default {
+  searchTopic,
+};

--- a/src/typedefs/index.ts
+++ b/src/typedefs/index.ts
@@ -1,0 +1,10 @@
+export interface News {
+  title: string;
+  content: string;
+}
+
+export interface OnlineNewsArticle extends News {
+  sourceName: string;
+  imageUrl?: string;
+  url?: string;
+}

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -1,0 +1,7 @@
+export default function(error: any) {
+  if (error.message) {
+    return error.message;
+  } else {
+    return 'An unexpected error occurred. Please try again later.';
+  }
+}


### PR DESCRIPTION
No nav buttons lead to /topics yet (unless if you navigated to /topics manually)
added TopicSearchResult, getTopicScoreMock, TopicPage, TopicService, typedefs and parseError